### PR TITLE
fix k3s_storage_endpoint being null in k3s script

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ locals {
   db_name                     = var.db_name != null ? var.db_name : var.name
   db_node_count               = var.k3s_storage_endpoint != "sqlite" ? var.db_node_count : 0
   k3s_storage_cafile          = var.k3s_storage_cafile
-  k3s_storage_endpoint        = var.k3s_storage_endpoint == "sqlite" ? null : "postgres://${local.db_user}:${local.db_pass}@${aws_rds_cluster.k3s.0.endpoint}/${local.db_name}"
+  k3s_storage_endpoint        = var.k3s_storage_endpoint == "sqlite" ? var.k3s_storage_endpoint : "postgres://${local.db_user}:${local.db_pass}@${aws_rds_cluster.k3s.0.endpoint}/${local.db_name}"
   k3s_disable_agent           = var.k3s_disable_agent ? "--disable-agent" : ""
   k3s_tls_san                 = var.k3s_tls_san != null ? var.k3s_tls_san : "--tls-san ${aws_lb.server-lb.dns_name}"
   k3s_deploy_traefik          = var.k3s_deploy_traefik ? "" : "--no-deploy traefik"


### PR DESCRIPTION
Hello,

This is a bug fix for when you are trying to use sqlite as the storage endpoint, the `k3s_install.sh` script fail because `k3s_storage_endpoint` is `null`.

Thank you